### PR TITLE
Fixa sekvensdiagrammen i mörkläget

### DIFF
--- a/architecture/diagrams/förskrivningskollen-oidc.md
+++ b/architecture/diagrams/förskrivningskollen-oidc.md
@@ -1,16 +1,16 @@
 ```mermaid 
 sequenceDiagram
 autonumber
-    box rgb(230,255,255) Region
+    box Region
         participant User
     end
-    box rgb(230,255,230) EHM
+    box EHM
         participant Client as Förskrivningskollen Client Server
     end
-    box rgb(230,255,255) Region/Ombud
+    box Region/Ombud
         participant OP as OpenID Provider (Autentication Server)
     end
-    box rgb(230,255,255) Region/Ombud
+    box Region/Ombud
         participant RS as Resource Server (Authorisation Server)
     end
 

--- a/architecture/diagrams/förskrivningskollen.md
+++ b/architecture/diagrams/förskrivningskollen.md
@@ -1,11 +1,11 @@
 ```mermaid 
 sequenceDiagram
 autonumber
-    box rgb(230,255,255) Region A
+    box Region A
     participant A as Användar-<br>browser
     participant B as IdP
     end
-    box rgb(230,255,230) EHM
+    box EHM
     participant C as SP Förskrivningskollen
     participant D as Förskrivningskollen
     end


### PR DESCRIPTION
# Pull Request Description

Sekvensdiagrammen sätter sina egna bakgrundsrutor, men textfärgen styrs av GitHubs mall. Tyvärr leder det till att kontrasten blir nästan oanvändbart låg om man använder GitHubs mörkerläge.

Före:

<img width="446" height="798" alt="image" src="https://github.com/user-attachments/assets/66fb4d82-c467-4b6f-b8a5-b6a2db387cb8" />

Efter:

<img width="446" height="798" alt="image" src="https://github.com/user-attachments/assets/bafa0e9c-d941-4436-8f49-63d001aaff05" />


## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
